### PR TITLE
[FEATURE] Added ability to play a human vs human game

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ INSERT STATUS BADGE HERE
 
 ### Prerequisites
 
-In order to run this project you will need to install Elixir and Pheonix.
+In order to run this project you will need to install Elixir, Pheonix, and PostgreSQL.
 ```sh
 Elixir 1.12
 Pheonix 1.6.10
+PostgreSQL 14.4
 ```
 
 
@@ -30,7 +31,7 @@ Pheonix 1.6.10
 
 1 Clone the repo
    ```sh
-git clone 
+git clone git@github.com:sethpthomas91/tic-tac-toe-backend.git
    ```
 
 2 Install dependencies 
@@ -38,11 +39,20 @@ git clone
 mix deps.get 
    ```
 
-3 Create and migrate your database with ``
+3 Create and migrate your database with
    ```sh
 mix ecto.setup
    ```
 
+Note:: If you run into any issues with the database try running
+   ```sh
+mix ecto.reset
+   ```
+This should reset and remigrate your database if their were any changes from a previous install. You may also have to reconfigure the following two files with your local settings for PostgreSQL
+   ```sh
+*/tic-tac-toe-backend/config/config.exs
+*tic-tac-toe-backend/config/dev.exs
+   ```
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ### Starting the Server

--- a/lib/tic_tac_toe_backend/game_data.ex
+++ b/lib/tic_tac_toe_backend/game_data.ex
@@ -1,0 +1,104 @@
+defmodule TicTacToeBackend.GameData do
+  @moduledoc """
+  The GameData context.
+  """
+
+  import Ecto.Query, warn: false
+  alias TicTacToeBackend.Repo
+
+  alias TicTacToeBackend.GameData.Game
+
+  @doc """
+  Returns the list of games.
+
+  ## Examples
+
+      iex> list_games()
+      [%Game{}, ...]
+
+  """
+  def list_games do
+    Repo.all(Game)
+  end
+
+  @doc """
+  Gets a single game.
+
+  Raises `Ecto.NoResultsError` if the Game does not exist.
+
+  ## Examples
+
+      iex> get_game!(123)
+      %Game{}
+
+      iex> get_game!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_game!(id), do: Repo.get!(Game, id)
+
+  @doc """
+  Creates a game.
+
+  ## Examples
+
+      iex> create_game(%{field: value})
+      {:ok, %Game{}}
+
+      iex> create_game(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_game(attrs \\ %{}) do
+    %Game{}
+    |> Game.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a game.
+
+  ## Examples
+
+      iex> update_game(game, %{field: new_value})
+      {:ok, %Game{}}
+
+      iex> update_game(game, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_game(%Game{} = game, attrs) do
+    game
+    |> Game.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a game.
+
+  ## Examples
+
+      iex> delete_game(game)
+      {:ok, %Game{}}
+
+      iex> delete_game(game)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_game(%Game{} = game) do
+    Repo.delete(game)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking game changes.
+
+  ## Examples
+
+      iex> change_game(game)
+      %Ecto.Changeset{data: %Game{}}
+
+  """
+  def change_game(%Game{} = game, attrs \\ %{}) do
+    Game.changeset(game, attrs)
+  end
+end

--- a/lib/tic_tac_toe_backend/game_data/game.ex
+++ b/lib/tic_tac_toe_backend/game_data/game.ex
@@ -1,0 +1,30 @@
+defmodule TicTacToeBackend.GameData.Game do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "games" do
+    field :available_moves, {:array, :integer}
+    field :best_score_move, :map
+    field :board, :map
+    field :current_player, :integer
+    field :maximizer, :integer
+    field :player_1_mark, :string
+    field :player_1_moves, {:array, :integer}
+    field :player_1_type, :string
+    field :player_2_mark, :string
+    field :player_2_moves, {:array, :integer}
+    field :player_2_type, :string
+    field :tied, :boolean, default: false
+    field :winner, :integer
+    field :won, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(game, attrs) do
+    game
+    |> cast(attrs, [:available_moves, :won, :tied, :winner, :player_1_moves, :player_2_moves, :player_1_mark, :player_2_mark, :current_player, :player_1_type, :player_2_type, :maximizer, :best_score_move, :board])
+    |> validate_required([:available_moves, :won, :tied, :winner, :player_1_moves, :player_2_moves, :player_1_mark, :player_2_mark, :current_player, :player_1_type, :player_2_type, :maximizer, :best_score_move, :board])
+  end
+end

--- a/lib/tic_tac_toe_backend_web/controllers/fallback_controller.ex
+++ b/lib/tic_tac_toe_backend_web/controllers/fallback_controller.ex
@@ -1,0 +1,24 @@
+defmodule TicTacToeBackendWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use TicTacToeBackendWeb, :controller
+
+  # This clause handles errors returned by Ecto's insert/update/delete.
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(TicTacToeBackendWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  # This clause is an example of how to handle resources that cannot be found.
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(TicTacToeBackendWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/tic_tac_toe_backend_web/controllers/game_controller.ex
+++ b/lib/tic_tac_toe_backend_web/controllers/game_controller.ex
@@ -1,0 +1,47 @@
+defmodule TicTacToeBackendWeb.GameController do
+  use TicTacToeBackendWeb, :controller
+
+  alias TicTacToeBackend.GameData
+  alias TicTacToeBackend.GameData.Game
+
+  action_fallback TicTacToeBackendWeb.FallbackController
+
+  def index(conn, _params) do
+    games = GameData.list_games()
+    render(conn, "index.json", games: games)
+  end
+
+  def create(conn, %{"game" => game_params}) do
+    with {:ok, %Game{} = game} <- GameData.create_game(game_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.game_path(conn, :show, game))
+      |> render("show.json", game: game)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    game = GameData.get_game!(id)
+    render(conn, "show.json", game: game)
+  end
+
+  def update(conn, %{"id" => id, "move" => move}) do
+    game = GameData.get_game!(id)
+
+    new_game_data =
+      GameLogic.convert_schema_to_map(game)
+      |> GameLogic.handle_game_logic(move)
+
+    with {:ok, %Game{} = game} <- GameData.update_game(game, new_game_data) do
+      render(conn, "show.json", game: game)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    game = GameData.get_game!(id)
+
+    with {:ok, %Game{}} <- GameData.delete_game(game) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/tic_tac_toe_backend_web/views/changeset_view.ex
+++ b/lib/tic_tac_toe_backend_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule TicTacToeBackendWeb.ChangesetView do
+  use TicTacToeBackendWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `TicTacToeBackendWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/tic_tac_toe_backend_web/views/game_view.ex
+++ b/lib/tic_tac_toe_backend_web/views/game_view.ex
@@ -1,0 +1,32 @@
+defmodule TicTacToeBackendWeb.GameView do
+  use TicTacToeBackendWeb, :view
+  alias TicTacToeBackendWeb.GameView
+
+  def render("index.json", %{games: games}) do
+    %{data: render_many(games, GameView, "game.json")}
+  end
+
+  def render("show.json", %{game: game}) do
+    %{data: render_one(game, GameView, "game.json")}
+  end
+
+  def render("game.json", %{game: game}) do
+    %{
+      id: game.id,
+      available_moves: game.available_moves,
+      won: game.won,
+      tied: game.tied,
+      winner: game.winner,
+      player_1_moves: game.player_1_moves,
+      player_2_moves: game.player_2_moves,
+      player_1_mark: game.player_1_mark,
+      player_2_mark: game.player_2_mark,
+      current_player: game.current_player,
+      player_1_type: game.player_1_type,
+      player_2_type: game.player_2_type,
+      maximizer: game.maximizer,
+      best_score_move: game.best_score_move,
+      board: game.board
+    }
+  end
+end

--- a/lib/tic_tac_toe_logic/game_logic.ex
+++ b/lib/tic_tac_toe_logic/game_logic.ex
@@ -1,0 +1,216 @@
+defmodule GameLogic do
+  @new_game %{
+    :available_moves => [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    :won => false,
+    :tied => false,
+    :winner => nil,
+    :player_1_moves => [],
+    :player_2_moves => [],
+    :player_1_mark => "X",
+    :player_2_mark => "O",
+    :current_player => 1,
+    :player_1_type => :human,
+    :player_2_type => :human,
+    :maximizer => nil,
+    :best_score_move => %{
+      :best_score => -100,
+      :best_move => nil
+    },
+    :board => %{
+      1 => "1",
+      2 => "2",
+      3 => "3",
+      4 => "4",
+      5 => "5",
+      6 => "6",
+      7 => "7",
+      8 => "8",
+      9 => "9"
+    }
+  }
+
+  def convert_schema_to_map(game) do
+    Map.drop(game, [:__meta__, :__struct__, :inserted_at, :updated_at])
+  end
+
+  def handle_game_logic(game, move) do
+    if (game[:tied] || game[:won]) do
+      game
+    else
+      new_game_data =
+        handle_move(move, game)
+        |> check_for_win()
+        |> check_for_tie()
+        |> change_player()
+    end
+  end
+
+  def new, do: @new_game
+
+  def won(game), do: game[:won]
+
+  def assign_player_1_mark(marker, game), do: %{game | player_1_mark: marker}
+
+  def assign_player_2_mark(marker, game), do: %{game | player_2_mark: marker}
+
+  def assign_game_win(false, game), do: game
+  def assign_game_win(won, game), do: %{game | won: won, winner: game.current_player}
+
+
+  def check_for_tie(game) do
+    if (length(get_available_moves(game)) == 0 && !won(game)) do
+      %{game | tied: true}
+    else
+      game
+    end
+  end
+
+  def check_for_win(game) do
+    won =
+      game[determine_move_list(game)]
+      |> check_for_win_combos()
+
+    assign_game_win(won, game)
+  end
+
+  def check_for_win_combos(moves) do
+    win_combos = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [1, 4, 7],
+      [2, 5, 8],
+      [3, 6, 9],
+      [1, 5, 9],
+      [3, 5, 7]
+    ]
+
+    win_combo_list =
+      Enum.map(win_combos, fn combo ->
+        Enum.map(combo, fn num ->
+          num in moves
+        end)
+      end)
+
+    win_list =
+      Enum.map(win_combo_list, fn combo ->
+        Enum.all?(combo)
+      end)
+
+    Enum.any?(win_list)
+  end
+
+  def change_player(game) when game.current_player == 1, do: %{game | current_player: 2}
+  def change_player(game), do: %{game | current_player: 1}
+
+  def determine_move_list(game) when game.current_player == 1, do: :player_1_moves
+  def determine_move_list(_game), do: :player_2_moves
+
+  def handle_move(move, game) do
+    player_move_list = determine_move_list(game)
+    game = update_available_moves(move, game)
+    game = update_player_move_list(game, player_move_list, move)
+    place_marker(move, game)
+  end
+
+  def update_available_moves(move, game) do
+    %{game | available_moves: List.delete(game.available_moves, move)}
+  end
+
+  def update_player_move_list(game, player_move_list, move) do
+    Map.replace(game, player_move_list, [move | game[player_move_list]])
+  end
+
+  def get_current_player(game), do: game[:current_player]
+
+  def get_available_moves(game), do: game[:available_moves]
+
+  def remove_move_from_available_moves(move, game),
+    do: List.delete(get_available_moves(game), move)
+
+  def get_random_move(game), do: Enum.random(get_available_moves(game))
+
+  def assign_player_2_type(type, game), do: %{game | player_2_type: type}
+  def assign_player_1_type(type, game), do: %{game | player_1_type: type}
+
+  def get_current_player_type(game) when game.current_player == 1, do: game.player_1_type
+  def get_current_player_type(game), do: game.player_2_type
+
+  # def determine_move_type(game) do
+  #   case get_current_player_type(game) do
+  #     :human -> handle_move(Display.get_user_move(game), game)
+  #     :random -> handle_random_move(game)
+  #     :next -> handle_next_move(game)
+  #     :best -> handle_move(best_move(game), game)
+  #   end
+  # end
+
+  def handle_random_move(game) do
+    move = get_random_move(game)
+    player_move_list = determine_move_list(game)
+    game = update_available_moves(move, game)
+    game = update_player_move_list(game, player_move_list, move)
+    place_marker(move, game)
+  end
+
+  def place_marker(move, game) do
+    update_board(Map.replace(game.board, Integer.to_string(move), get_marker(game)), game)
+  end
+
+  def get_marker(game) when game.current_player == 1, do: game.player_1_mark
+  def get_marker(game), do: game.player_2_mark
+
+  def update_board(board, game), do: %{game | board: board}
+
+  def next_open(game), do: List.first(get_available_moves(game))
+
+  def handle_next_move(game) do
+    move = next_open(game)
+    player_move_list = determine_move_list(game)
+    game = update_available_moves(move, game)
+    game = update_player_move_list(game, player_move_list, move)
+    place_marker(move, game)
+  end
+
+  def best_move(game) do
+    assign_maximizer(game)
+    |> minimax()
+  end
+
+  def assign_maximizer(game), do: %{game | maximizer: game.current_player}
+
+  def assign_winner(game), do: %{game | winner: game.current_player}
+
+  def score(%{won: false, available_moves: []}), do: 0
+  def score(%{winner: winner, won: true, maximizer: maximizer}) when winner == maximizer, do: 10
+  def score(%{won: true}), do: -10
+  def score(game), do: game
+
+  def terminal_state(%{won: false, available_moves: []}), do: true
+  def terminal_state(%{won: true}), do: true
+  def terminal_state(_), do: false
+
+  def minimax(game) do
+    game = check_for_win(game)
+
+    if terminal_state(game) do
+      score(game)
+    else
+      next_games =
+        Enum.map(game.available_moves, fn move ->
+          game = handle_move(move, change_player(game))
+          %{game | best_score_move: %{:best_score => minimax(game), :best_move => move}}
+        end)
+
+      case game.current_player == game.maximizer do
+        true ->
+          best_game = Enum.min_by(next_games, fn game -> game.best_score_move.best_score end)
+          best_game.best_score_move.best_move
+
+        false ->
+          best_game = Enum.max_by(next_games, fn game -> game.best_score_move.best_score end)
+          best_game.best_score_move.best_move
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20220707164525_create_games.exs
+++ b/priv/repo/migrations/20220707164525_create_games.exs
@@ -1,0 +1,24 @@
+defmodule TicTacToeBackend.Repo.Migrations.CreateGames do
+  use Ecto.Migration
+
+  def change do
+    create table(:games) do
+      add :available_moves, {:array, :integer}
+      add :won, :boolean, default: false, null: false
+      add :tied, :boolean, default: false, null: false
+      add :winner, :integer
+      add :player_1_moves, {:array, :integer}
+      add :player_2_moves, {:array, :integer}
+      add :player_1_mark, :string
+      add :player_2_mark, :string
+      add :current_player, :integer
+      add :player_1_type, :string
+      add :player_2_type, :string
+      add :maximizer, :integer
+      add :best_score_move, :map
+      add :board, :map
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/fixtures/game_data_fixtures.ex
+++ b/test/support/fixtures/game_data_fixtures.ex
@@ -1,0 +1,33 @@
+defmodule TicTacToeBackend.GameDataFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `TicTacToeBackend.GameData` context.
+  """
+
+  @doc """
+  Generate a game.
+  """
+  def game_fixture(attrs \\ %{}) do
+    {:ok, game} =
+      attrs
+      |> Enum.into(%{
+        available_moves: [],
+        best_score_move: %{},
+        board: %{},
+        current_player: 42,
+        maximizer: 42,
+        player_1_mark: "some player_1_mark",
+        player_1_moves: [],
+        player_1_type: "some player_1_type",
+        player_2_mark: "some player_2_mark",
+        player_2_moves: [],
+        player_2_type: "some player_2_type",
+        tied: true,
+        winner: 42,
+        won: true
+      })
+      |> TicTacToeBackend.GameData.create_game()
+
+    game
+  end
+end

--- a/test/tic_tac_toe_backend/game_data_test.exs
+++ b/test/tic_tac_toe_backend/game_data_test.exs
@@ -1,0 +1,85 @@
+defmodule TicTacToeBackend.GameDataTest do
+  use TicTacToeBackend.DataCase
+
+  alias TicTacToeBackend.GameData
+
+  describe "games" do
+    alias TicTacToeBackend.GameData.Game
+
+    import TicTacToeBackend.GameDataFixtures
+
+    @invalid_attrs %{available_moves: nil, best_score_move: nil, board: nil, current_player: nil, maximizer: nil, player_1_mark: nil, player_1_moves: nil, player_1_type: nil, player_2_mark: nil, player_2_moves: nil, player_2_type: nil, tied: nil, winner: nil, won: nil}
+
+    test "list_games/0 returns all games" do
+      game = game_fixture()
+      assert GameData.list_games() == [game]
+    end
+
+    test "get_game!/1 returns the game with given id" do
+      game = game_fixture()
+      assert GameData.get_game!(game.id) == game
+    end
+
+    test "create_game/1 with valid data creates a game" do
+      valid_attrs = %{available_moves: [], best_score_move: %{}, board: %{}, current_player: 42, maximizer: 42, player_1_mark: "some player_1_mark", player_1_moves: [], player_1_type: "some player_1_type", player_2_mark: "some player_2_mark", player_2_moves: [], player_2_type: "some player_2_type", tied: true, winner: 42, won: true}
+
+      assert {:ok, %Game{} = game} = GameData.create_game(valid_attrs)
+      assert game.available_moves == []
+      assert game.best_score_move == %{}
+      assert game.board == %{}
+      assert game.current_player == 42
+      assert game.maximizer == 42
+      assert game.player_1_mark == "some player_1_mark"
+      assert game.player_1_moves == []
+      assert game.player_1_type == "some player_1_type"
+      assert game.player_2_mark == "some player_2_mark"
+      assert game.player_2_moves == []
+      assert game.player_2_type == "some player_2_type"
+      assert game.tied == true
+      assert game.winner == 42
+      assert game.won == true
+    end
+
+    test "create_game/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = GameData.create_game(@invalid_attrs)
+    end
+
+    test "update_game/2 with valid data updates the game" do
+      game = game_fixture()
+      update_attrs = %{available_moves: [], best_score_move: %{}, board: %{}, current_player: 43, maximizer: 43, player_1_mark: "some updated player_1_mark", player_1_moves: [], player_1_type: "some updated player_1_type", player_2_mark: "some updated player_2_mark", player_2_moves: [], player_2_type: "some updated player_2_type", tied: false, winner: 43, won: false}
+
+      assert {:ok, %Game{} = game} = GameData.update_game(game, update_attrs)
+      assert game.available_moves == []
+      assert game.best_score_move == %{}
+      assert game.board == %{}
+      assert game.current_player == 43
+      assert game.maximizer == 43
+      assert game.player_1_mark == "some updated player_1_mark"
+      assert game.player_1_moves == []
+      assert game.player_1_type == "some updated player_1_type"
+      assert game.player_2_mark == "some updated player_2_mark"
+      assert game.player_2_moves == []
+      assert game.player_2_type == "some updated player_2_type"
+      assert game.tied == false
+      assert game.winner == 43
+      assert game.won == false
+    end
+
+    test "update_game/2 with invalid data returns error changeset" do
+      game = game_fixture()
+      assert {:error, %Ecto.Changeset{}} = GameData.update_game(game, @invalid_attrs)
+      assert game == GameData.get_game!(game.id)
+    end
+
+    test "delete_game/1 deletes the game" do
+      game = game_fixture()
+      assert {:ok, %Game{}} = GameData.delete_game(game)
+      assert_raise Ecto.NoResultsError, fn -> GameData.get_game!(game.id) end
+    end
+
+    test "change_game/1 returns a game changeset" do
+      game = game_fixture()
+      assert %Ecto.Changeset{} = GameData.change_game(game)
+    end
+  end
+end

--- a/test/tic_tac_toe_backend_web/controllers/game_controller_test.exs
+++ b/test/tic_tac_toe_backend_web/controllers/game_controller_test.exs
@@ -1,0 +1,102 @@
+defmodule TicTacToeBackendWeb.GameControllerTest do
+  use TicTacToeBackendWeb.ConnCase
+
+  import TicTacToeBackend.GameDataFixtures
+
+  alias TicTacToeBackend.GameData.Game
+
+  @create_attrs %{
+    available_moves: [],
+    best_score_move: %{},
+    board: %{},
+    current_player: 42,
+    maximizer: 42,
+    player_1_mark: "some player_1_mark",
+    player_1_moves: [],
+    player_1_type: "some player_1_type",
+    player_2_mark: "some player_2_mark",
+    player_2_moves: [],
+    player_2_type: "some player_2_type",
+    tied: true,
+    winner: 42,
+    won: true
+  }
+  @update_attrs %{
+    available_moves: [],
+    best_score_move: %{},
+    board: %{},
+    current_player: 43,
+    maximizer: 43,
+    player_1_mark: "some updated player_1_mark",
+    player_1_moves: [],
+    player_1_type: "some updated player_1_type",
+    player_2_mark: "some updated player_2_mark",
+    player_2_moves: [],
+    player_2_type: "some updated player_2_type",
+    tied: false,
+    winner: 43,
+    won: false
+  }
+  @invalid_attrs %{available_moves: nil, best_score_move: nil, board: nil, current_player: nil, maximizer: nil, player_1_mark: nil, player_1_moves: nil, player_1_type: nil, player_2_mark: nil, player_2_moves: nil, player_2_type: nil, tied: nil, winner: nil, won: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all games", %{conn: conn} do
+      conn = get(conn, Routes.game_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create game" do
+    test "renders game when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.game_path(conn, :create), game: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.game_path(conn, :show, id))
+
+      assert %{
+               "id" => ^id,
+               "available_moves" => [],
+               "best_score_move" => %{},
+               "board" => %{},
+               "current_player" => 42,
+               "maximizer" => 42,
+               "player_1_mark" => "some player_1_mark",
+               "player_1_moves" => [],
+               "player_1_type" => "some player_1_type",
+               "player_2_mark" => "some player_2_mark",
+               "player_2_moves" => [],
+               "player_2_type" => "some player_2_type",
+               "tied" => true,
+               "winner" => 42,
+               "won" => true
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.game_path(conn, :create), game: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete game" do
+    setup [:create_game]
+
+    test "deletes chosen game", %{conn: conn, game: game} do
+      conn = delete(conn, Routes.game_path(conn, :delete, game))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.game_path(conn, :show, game))
+      end
+    end
+  end
+
+  defp create_game(_) do
+    game = game_fixture()
+    %{game: game}
+  end
+end


### PR DESCRIPTION
### Added
* Updated README to reflect workflow status badge.
* Added Cell and Board Tests
### Changed
* Built a new application instead of using the pre-made tabs.
* A game is updated by sending a move and game ID to the backend. You cannot change games using the game object
now.
* Navigation is now based on the navigation hook
* Changed naming of Box to Cell.
### Removed
* Pre-built tabs and some automatically generated files from expo.
### Fixed
* Fixed yml file to run npm test.

---

### Pre-merge Checklist
- [x] All tests pass
- [x] Consider impact to other teams/services
- [x] Update documentation
